### PR TITLE
[input] add logic to handle native select elements in form fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10100,11 +10100,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10117,15 +10119,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10228,7 +10233,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10238,6 +10244,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10250,17 +10257,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -10277,6 +10287,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10349,7 +10360,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10359,6 +10371,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10464,6 +10477,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6885,6 +6885,12 @@
         }
       }
     },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
+      "dev": true
+    },
     "caniuse-api": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
@@ -7748,6 +7754,12 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+      "dev": true
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -7842,6 +7854,17 @@
             "regjsparser": "^0.1.4"
           }
         }
+      }
+    },
+    "css-to-react-native": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.0.tgz",
+      "integrity": "sha512-IhR7bNIrCFwbJbKZOAjNDZdwpsbjTN6f1agXeELHDqg1wHPA8c2QLruttKOW7hgMGetkfraRJCIEMrptifBfVw==",
+      "dev": true,
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^3.3.0"
       }
     },
     "css-tree": {
@@ -10956,6 +10979,12 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -16077,6 +16106,12 @@
         "prop-types": "^15.6.1"
       }
     },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -17797,6 +17832,62 @@
         "loader-utils": "^1.0.2",
         "schema-utils": "^0.3.0"
       }
+    },
+    "styled-components": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
+      "integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.0.3",
+        "css-to-react-native": "^2.0.3",
+        "fbjs": "^0.8.16",
+        "hoist-non-react-statics": "^2.5.0",
+        "prop-types": "^15.5.4",
+        "react-is": "^16.3.1",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10",
+        "supports-color": "^3.2.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "stylis": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
+      "dev": true
+    },
+    "stylis-rule-sheet": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
+      "dev": true
     },
     "supports-color": {
       "version": "5.4.0",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,10 @@
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.2",
     "rollup-plugin-node-resolve": "^4.0.1",
-    "rollup-plugin-peer-deps-external": "^2.2.0"
+    "rollup-plugin-peer-deps-external": "^2.2.0",
+    "styled-components": "^3.4.10"
   },
   "peerDependencies": {
-    "styled-components": "^3.3.3"
+    "styled-components": ">=3.3.3"
   }
 }

--- a/src/lib/form-field/styles/index.js
+++ b/src/lib/form-field/styles/index.js
@@ -6,7 +6,7 @@ import outlineAppearanceThunk from './outline-style';
 import { outlineThemeThunk, outlineTypographyThunk } from './outline-theme';
 import fillAppearanceThunk from './fill-style';
 import { fillThemeThunk, fillTypographyThunk} from './fill-theme';
-import {SELECT_PLACEHOLDER_ARROW_SPACE} from '../../select/styles';
+import {SELECT_PLACEHOLDER_ARROW_SPACE, SELECT_ARROW_MARGIN, SELECT_ARROW_SIZE} from '../../select/styles';
 import {formFieldBaseThemeMixin, typographyThunk } from './theme-base';
 import { TYPOGRAPHY_DEFAULTS } from '../../text';
 
@@ -188,6 +188,16 @@ text-align: left;
   
   ${FormFieldLabel} {
     width: calc(100% - ${SELECT_PLACEHOLDER_ARROW_SPACE}px);
+  }
+}
+
+&[data-field-type=native-select], &[data-field-type=native-select-multiple] {
+  ${FormFieldLabelWrapper} {
+    max-width: calc(100% - ${SELECT_ARROW_SIZE * 2}px);
+  }
+  
+  ${FormFieldInfix} {
+    line-height: 1em;
   }
 }
 

--- a/src/lib/form-field/styles/outline-theme.js
+++ b/src/lib/form-field/styles/outline-theme.js
@@ -16,6 +16,10 @@ export const outlineThemeThunk = (components) => {
     border-color: ${UNFILLED_BORDER};
   }
   
+  &[data-field-type=native-select][data-value=empty] select {
+    color: ${DEFAULT_BORDER};
+  }
+  
   // Lowest priority of enabled states
   &[data-value=filled] {
     ${FormFieldBar} {

--- a/src/lib/form-field/styles/theme-base.js
+++ b/src/lib/form-field/styles/theme-base.js
@@ -5,6 +5,7 @@ import { getLineHeight } from '../../text';
 import { convertLevelToStyles } from '../../text/styles/utils';
 
 const DEFAULT_TEXT = GREY[900];
+const ARROW_STROKE = GREY[700];
 const PRIMARY = GREEN[500];
 const WARN = RED[500];
 const REQUIRED_LABEL_COLOR = WARN;
@@ -132,6 +133,17 @@ export const typographyThunk = (components, config) => {
     the padding amount
      */
     top: calc(100% - ${WRAPPER_PADDING_BOTTOM / SUBSCRIPT_FONT_SCALE}em);
+  }
+  `;
+};
+
+/** Themes for the native select (arrow mostly) */
+export const nativeSelectThemeThunk = (components) => {
+  const { Arrow } = components;
+  return css`
+  ${Arrow} {
+    fill: none;
+    stroke: ${ARROW_STROKE};
   }
   `;
 };

--- a/src/lib/input/Input.js
+++ b/src/lib/input/Input.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { FormFieldDefaultProps, FormFieldPropTypes, withFormFieldConsumer } from '../form-field';
 import { withPlatformConsumer, PlatformDefaultProps, PlatformPropTypes } from '../../cdk/platform';
-import { BaseInput, BaseTextArea } from './styles/index';
+import { BaseInput, BaseSelect, BaseTextArea } from './styles/index';
 import { INVALID_INPUT_TYPES } from './constants';
 import { PROP_TYPE_STRING_OR_NUMBER } from '../../cdk/util/props';
 import { stack } from '../core/components/util';
@@ -29,9 +29,18 @@ class Input extends React.Component {
     };
 
     // Determine the type to show. this is NOT reactive
-    this.INPUT_TYPE = _.toLower(props.as) === 'input' ?
-      BaseInput :
-      BaseTextArea;
+    switch (_.toLower(props.as)) {
+      case 'select':
+        this.INPUT_TYPE = BaseSelect;
+        break;
+      case 'textarea':
+        this.INPUT_TYPE = BaseTextArea;
+        break;
+      case 'input':
+      default:
+        this.INPUT_TYPE = BaseInput;
+        break;
+    }
 
     this.DEFAULT_ID = _.uniqueId('sui-input:');
 

--- a/src/lib/input/Input.js
+++ b/src/lib/input/Input.js
@@ -13,6 +13,8 @@ import {
   ExtensionPropTypes,
   withExtensionManager
 } from '../form-field/context/ExtensionsContext';
+import { SelectArrow, SelectArrowWrapper, SelectTrigger, SelectValue } from '../select/styles';
+import { NativeSelectArrow, NativeSelectArrowWrapper } from './styles';
 
 /**
  * The input and text area components contain very similar behavior
@@ -74,7 +76,7 @@ class Input extends React.Component {
     /** Check to see which type of underlying control we are, and then make modifications */
     let as = this.props.as;
     if (as === 'select') {
-      as = this.props.multiple ? 'select-multiple' : as;
+      as = this.props.multiple ? 'native-select-multiple' : 'native-select';
     }
     this.props.__formFieldControl.setControlType(as);
 
@@ -282,6 +284,11 @@ class Input extends React.Component {
           onBlur={this.handleFocusChange(false)}
           innerRef={this.getInputRef}
         />
+        { this.props.as === 'select' ? (
+          <NativeSelectArrowWrapper>
+            <NativeSelectArrow />
+          </NativeSelectArrowWrapper>
+        ) : null }
       </React.Fragment>
     );
   }

--- a/src/lib/input/Input.js
+++ b/src/lib/input/Input.js
@@ -61,7 +61,13 @@ class Input extends React.Component {
 
     // set the onContainerClick
     this.props.__formFieldControl.setContainerClick(this.onContainerClick);
-    this.props.__formFieldControl.setControlType(this.props.as);
+
+    /** Check to see which type of underlying control we are, and then make modifications */
+    let as = this.props.as;
+    if (as === 'select') {
+      as = this.props.multiple ? 'select-multiple' : as;
+    }
+    this.props.__formFieldControl.setControlType(as);
 
     // handle the iOS bug
     handleIOSQuirk.call(this);
@@ -98,6 +104,9 @@ class Input extends React.Component {
   /**
    * Derived data
    */
+  /** If the underlying DOM element is a select */
+  isNativeSelect = () => this.props.as === 'select';
+
   /** Get the root input element */
   getInputRef = (input) => {
     this.EL = input;
@@ -252,7 +261,7 @@ class Input extends React.Component {
           type={as === 'input' ? type : undefined}
           id={this.getId()}
           placeholder={placeholder}
-          readOnly={readOnly}
+          readOnly={readOnly && !this.isNativeSelect() || null}
           required={required}
           aria-describedby={this.getAriaDescribedBy()}
           aria-invalid={false}
@@ -272,8 +281,8 @@ class Input extends React.Component {
 const InputPropTypes = {
   /** The id associated with the input field */
   id: PROP_TYPE_STRING_OR_NUMBER,
-  /** The DOM node type, either a textarea or an input */
-  as: PropTypes.oneOf(['textarea', 'input']),
+  /** The DOM node type, either a textarea or an input, OR native select */
+  as: PropTypes.oneOf(['textarea', 'input', 'select']),
   /** Placeholder -- required for FormFieldControl */
   placeholder: PROP_TYPE_STRING_OR_NUMBER,
   /** Whether or not the field is disabled -- FormFieldControl */
@@ -355,6 +364,7 @@ function handleIOSQuirk() {
   if (this.props.__platform.is('ios') && this.EL) {
     this.EL.addEventListener('keyup', (event) => {
       const el = event.target;
+      /** Checking these properties already detects if it's input-like or a native select */
       if (!el.value && !el.selectionStart && !el.selectionEnd) {
         // Note: Just setting `0, 0` doesn't fix the issue. Setting
         // `1, 1` fixes it for the first time that you type text and

--- a/src/lib/input/styles/index.js
+++ b/src/lib/input/styles/index.js
@@ -161,7 +161,7 @@ ${typographyThunk(TYPOGRAPHY_DEFAULTS)}
 
 [data-field-type=native-select] &, [data-field-type=native-select-multiple] & {
   padding-right: ${SELECT_ARROW_SIZE * 3}px;
-  max-width: calc(100% - ${SELECT_ARROW_SIZE * 3}px);
+  text-overflow: ellipsis;
   
   [dir=rtl] & {
     padding-right: 0;
@@ -181,8 +181,10 @@ export const NativeSelectArrowWrapper = SelectArrowWrapper.extend`
   display: inline-block;
   white-space: nowrap;
   flex: 0 0 auto;
-  position: relative;
+  position: absolute;
   bottom: 1px;
+  right: 0;
+  pointer-events: none;
 
   ${NativeSelectArrow} {
     height: 10px;

--- a/src/lib/input/styles/index.js
+++ b/src/lib/input/styles/index.js
@@ -4,6 +4,8 @@ import { EASE_OUT } from '../../core/styles/animation';
 import { PLACEHOLDER } from '../../core/styles/vendor';
 import {TEXT_FIELD_AUTOFILL_MONITOR} from '../../../cdk/text-area/styles';
 import { TYPOGRAPHY_DEFAULTS } from '../../text';
+import { SELECT_ARROW_SIZE, SelectArrowWrapper, SelectArrow } from '../../select/styles';
+import { nativeSelectThemeThunk } from '../../form-field/styles/theme-base';
 
 const baseInput = css`
 // Font needs to be inherited, because by default <input> has a system font.
@@ -105,10 +107,89 @@ ${PLACEHOLDER(`
 ${TEXT_FIELD_AUTOFILL_MONITOR}
 `;
 
+/**
+ * Base styling for native select elements. Must replace default arrow with Signature UI chevron.
+ */
+const baseSelect = css`
+  ${baseInput}
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  position: relative;
+  background-color: transparent;
+  display: inline-flex;
+  box-sizing: border-box;
+  padding-top: 1em;
+  top: -1em;
+  margin-bottom: -1em;
+
+  &::-ms-expand {
+    display: none;
+  }
+
+  // The \`outline: none\` from \`.mat-input-element\` works on all browsers, however Firefox also
+  // adds a special \`focus-inner\` which we have to disable explicitly. See:
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Firefox
+  &::-moz-focus-inner {
+    border: 0;
+  }
+
+  &:not(:disabled) {
+    cursor: pointer;
+  }
+
+  // As a part of its user agent styling, IE11 has a blue box inside each focused
+  // \`select\` element which we have to reset. Note that this needs to be in its own
+  // selector, because having it together with another one will cause other browsers
+  // to ignore it.
+  &::-ms-value {
+    // We need to reset the \`color\` as well, because IE sets it to white.
+    color: inherit;
+    background: none;
+  }
+`;
+
 export const BaseInput = styled.input`
 ${baseInput}
 ${themeThunk()}
 ${typographyThunk(TYPOGRAPHY_DEFAULTS)}
+`;
+
+export const BaseSelect = styled.select`
+${baseSelect}
+${themeThunk()}
+${typographyThunk(TYPOGRAPHY_DEFAULTS)}
+
+[data-field-type=native-select] &, [data-field-type=native-select-multiple] & {
+  padding-right: ${SELECT_ARROW_SIZE * 3}px;
+  max-width: calc(100% - ${SELECT_ARROW_SIZE * 3}px);
+  
+  [dir=rtl] & {
+    padding-right: 0;
+    padding-left: ${SELECT_ARROW_SIZE * 3}px;
+  }
+}
+`;
+
+/**
+ * Styles for the SUI arrow
+ */
+
+export const NativeSelectArrow = SelectArrow.extend`
+`;
+
+export const NativeSelectArrowWrapper = SelectArrowWrapper.extend`
+  display: inline-block;
+  white-space: nowrap;
+  flex: 0 0 auto;
+  position: relative;
+  bottom: 1px;
+
+  ${NativeSelectArrow} {
+    height: 10px;
+    width: 16px;
+  }
+  
+  ${nativeSelectThemeThunk({ Arrow: NativeSelectArrow })}
 `;
 
 export const BaseTextArea = styled.textarea`

--- a/src/lib/select/styles/index.js
+++ b/src/lib/select/styles/index.js
@@ -6,8 +6,8 @@ import { EASE_OUT } from '../../core/styles/animation';
 import {ChevronIcon} from '../../core/icons';
 import {selectPanelThemeThunk, selectRootThemeThunk} from './theme';
 
-const SELECT_ARROW_MARGIN = 4; // px
-const SELECT_ARROW_SIZE = 8; // px
+export const SELECT_ARROW_MARGIN = 4; // px
+export const SELECT_ARROW_SIZE = 8; // px
 
 // For use in FormField
 export const SELECT_PLACEHOLDER_ARROW_SPACE = 2 * (

--- a/src/storybook-app/Input.stories.js
+++ b/src/storybook-app/Input.stories.js
@@ -6,6 +6,7 @@ import InputHints from './Input/Hints';
 import { CenteredDecorator } from './styles';
 import InputClearable from './Input/Clearable';
 import InputAutosize from './Input/Autosize';
+import InputNativeSelect from './Input/NativeSelect';
 import inputOverview from './Input/notes/InputOverview.md';
 
 storiesOf('Input & TextArea', module)
@@ -18,4 +19,5 @@ storiesOf('Input & TextArea', module)
   .add('with prefixes and suffixes', () => <InputPrefixSuffix />)
   .add('with hints', () => <InputHints />)
   .add('with clearing feature', () => <InputClearable />)
-  .add('with autosize', () => <InputAutosize />);
+  .add('with autosize', () => <InputAutosize />)
+  .add('as native select', () => <InputNativeSelect />);

--- a/src/storybook-app/Input/NativeSelect.js
+++ b/src/storybook-app/Input/NativeSelect.js
@@ -22,6 +22,7 @@ class NativeSelect extends React.Component {
           value={this.state.value}
           onChange={this.updateCarType}
         >
+          <option value="">Select</option>
           <option value="volvo">Volvo</option>
           <option value="saab">Saab</option>
           <option value="mercedes">Mercedes</option>

--- a/src/storybook-app/Input/NativeSelect.js
+++ b/src/storybook-app/Input/NativeSelect.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { FormField, Label, Prefix } from '../../lib/form-field';
+import { Input } from '../../lib/input';
+
+class NativeSelect extends React.Component {
+  constructor() {
+    super();
+
+    this.state = { value: '' };
+  }
+
+  updateCarType = (event) => {
+    this.setState({ value: event.target.value });
+  };
+
+  render() {
+    return (
+      <FormField>
+        <Label>Telephone number</Label>
+        <Prefix>
+          +1&nbsp;
+        </Prefix>
+        <Input
+          as="select"
+          value={this.state.value}
+          onChange={this.updateCarType}
+          placeholder="Favorite car brand"
+        >
+          <option value="volvo">Volvo</option>
+          <option value="saab">Saab</option>
+          <option value="mercedes">Mercedes</option>
+          <option value="audi">Audi</option>
+        </Input>
+      </FormField>
+    );
+  }
+}
+
+export default NativeSelect;

--- a/src/storybook-app/Input/NativeSelect.js
+++ b/src/storybook-app/Input/NativeSelect.js
@@ -16,15 +16,11 @@ class NativeSelect extends React.Component {
   render() {
     return (
       <FormField>
-        <Label>Telephone number</Label>
-        <Prefix>
-          +1&nbsp;
-        </Prefix>
+        <Label>Favorite car brand</Label>
         <Input
           as="select"
           value={this.state.value}
           onChange={this.updateCarType}
-          placeholder="Favorite car brand"
         >
           <option value="volvo">Volvo</option>
           <option value="saab">Saab</option>


### PR DESCRIPTION
# Overview
The `Select` component will not be completed in time for the rebranding, but Angular Material offers a solution for those who wish to use native `<select>` elements instead.

This change adds some missing logic to handle the native select logic in the `<Input />` components. (This was done instead of creating another `NativeSelect` component because Angular Material handles this reusable logic through _directives_, which is pretty difficult to isolate/accomplish in React.) This is a practical solution for now and can be replaced later once the Signature UI-spec `Select` element is completed.

# Testing
Run `npm run storybook` and check out the "Input & TextArea > with native select" storybook section.

Please test in all browsers.

If you would like to test this as an end developer, please download this branch and then recreate a component similar to how it is in the `storybook-app/Input/NativeSelect.js` file.

# Meta
Welcome to the first Signature UI PR! Please let me know if you have any suggestions for SUI PR templates.