### PR TITLE
[form field] add data-attribute on form field bar to enable colored backgrounds

### DIFF
--- a/src/lib/button/Button.js
+++ b/src/lib/button/Button.js
@@ -5,9 +5,6 @@ import { ButtonRoot, ButtonFocusOverlay, ButtonWrapper } from './styles/index';
 import { FocusMonitorPropTypes, FocusMonitorDefaultProps, withFocusMonitor } from '../../cdk/a11y';
 import { ButtonDisabledOverlay } from './styles';
 
-/** Default color palette for round buttons (mat-fab and mat-mini-fab) */
-const DEFAULT_ROUND_BUTTON_COLOR = 'accent';
-
 class Button extends React.Component {
   constructor(props) {
     super(props);
@@ -74,12 +71,12 @@ class Button extends React.Component {
   };
   
   render() {
-    const { appearance, size, as, color, __focusMonitor, ...restProps } = this.props;
+    const { appearance, size, is, color, __focusMonitor, ...restProps } = this.props;
     return (
       <ButtonRoot
         {...restProps}
         {...this.getNodeAttrs()}
-        as={as}
+        as={is}
         data-sui-type={'button'}
         data-appearance={appearance}
         data-size={size}
@@ -98,7 +95,7 @@ class Button extends React.Component {
 
 const ButtonPropTypes = {
   /** HTML element */
-  as: PropTypes.oneOf(['button', 'a']),
+  is: PropTypes.oneOf(['button', 'a']),
   /** Whether or not the button is disabled */
   disabled: PropTypes.bool,
   /** appearance, one of standard, flat, icon, raised, stroked, floating */
@@ -110,7 +107,7 @@ const ButtonPropTypes = {
 };
 
 const ButtonDefaultProps = {
-  as: 'button',
+  is: 'button',
   disabled: false,
   appearance: 'standard',
   size: 'standard',

--- a/src/lib/form-field/FormField.js
+++ b/src/lib/form-field/FormField.js
@@ -232,7 +232,7 @@ export default class FormField extends React.Component {
                 onClick={this.state.containerClick}
                 ref={this.connectionContainer}
               >
-                <FormFieldBar>
+                <FormFieldBar data-hook="form-field-bar">
                   { prefix ? <FormFieldPrefix>{ prefix }</FormFieldPrefix> : null }
                   <FormFieldInfix>
                     { // don't pass through the hints, otherwise it'll show up twice

--- a/src/lib/input/Input.js
+++ b/src/lib/input/Input.js
@@ -13,7 +13,6 @@ import {
   ExtensionPropTypes,
   withExtensionManager
 } from '../form-field/context/ExtensionsContext';
-import { SelectArrow, SelectArrowWrapper, SelectTrigger, SelectValue } from '../select/styles';
 import { NativeSelectArrow, NativeSelectArrowWrapper } from './styles';
 
 /**
@@ -31,7 +30,7 @@ class Input extends React.Component {
     };
 
     // Determine the type to show. this is NOT reactive
-    switch (_.toLower(props.as)) {
+    switch (_.toLower(props.is)) {
       case 'select':
         this.INPUT_TYPE = BaseSelect;
         break;
@@ -74,7 +73,7 @@ class Input extends React.Component {
     this.props.__formFieldControl.setContainerClick(this.onContainerClick);
 
     /** Check to see which type of underlying control we are, and then make modifications */
-    let as = this.props.as;
+    let as = this.props.is;
     if (as === 'select') {
       as = this.props.multiple ? 'native-select-multiple' : 'native-select';
     }
@@ -116,7 +115,7 @@ class Input extends React.Component {
    * Derived data
    */
   /** If the underlying DOM element is a select */
-  isNativeSelect = () => this.props.as === 'select';
+  isNativeSelect = () => this.props.is === 'select';
 
   /** Get the root input element */
   getInputRef = (input) => {
@@ -247,7 +246,7 @@ class Input extends React.Component {
 
   render() {
     const {
-      as, id, placeholder, disabled, required, type,
+      is, id, placeholder, disabled, required, type,
       __extensionManager,
       extensions, readOnly, __formFieldControl, ...restProps
     } = this.props;
@@ -269,7 +268,7 @@ class Input extends React.Component {
           disabled={disabled}
           {...restProps}
           {...extendedAttributes}
-          type={as === 'input' ? type : undefined}
+          type={is === 'input' ? type : undefined}
           id={this.getId()}
           placeholder={placeholder}
           readOnly={readOnly && !this.isNativeSelect() || null}
@@ -284,7 +283,7 @@ class Input extends React.Component {
           onBlur={this.handleFocusChange(false)}
           ref={this.getInputRef}
         />
-        { this.props.as === 'select' ? (
+        { this.props.is === 'select' ? (
           <NativeSelectArrowWrapper>
             <NativeSelectArrow />
           </NativeSelectArrowWrapper>
@@ -298,7 +297,7 @@ const InputPropTypes = {
   /** The id associated with the input field */
   id: PROP_TYPE_STRING_OR_NUMBER,
   /** The DOM node type, either a textarea or an input, OR native select */
-  as: PropTypes.oneOf(['textarea', 'input', 'select']),
+  is: PropTypes.oneOf(['textarea', 'input', 'select']),
   /** Placeholder -- required for FormFieldControl */
   placeholder: PROP_TYPE_STRING_OR_NUMBER,
   /** Whether or not the field is disabled -- FormFieldControl */
@@ -310,7 +309,7 @@ const InputPropTypes = {
   /** Associated only with as="input" fields */
   type: function(props, propName, componentName) {
     // Don't bother if it's a textarea
-    if (_.toLower(props.as) === 'textarea') return null;
+    if (_.toLower(props.is) === 'textarea') return null;
 
     const type = props[propName];
     if (!type || !_.isString(type)) {
@@ -331,7 +330,7 @@ const InputPropTypes = {
 
 const InputDefaultProps = {
   id: '',
-  as: 'input',
+  is: 'input',
   placeholder: '',
   disabled: false,
   required: false,

--- a/src/storybook-app/FormField.stories.js
+++ b/src/storybook-app/FormField.stories.js
@@ -5,6 +5,7 @@ import { FormField, Suffix, Label, Hint } from '../lib/form-field';
 import { Input } from '../lib/input';
 import PrefixSuffix from './FormField/PrefixSuffix';
 import AutofillExample from './FormField/AutofillExample';
+import StyledBackground from './FormField/StyledBackground';
 
 storiesOf('FormField', module)
   .add('Available styles', () => (
@@ -34,4 +35,5 @@ storiesOf('FormField', module)
   .add('Prefixes and suffixes', () => (
     <PrefixSuffix />
   ))
-  .add('Autofill monitor example', () => <AutofillExample />);
+  .add('Autofill monitor example', () => <AutofillExample />)
+  .add('with styled background', () => <StyledBackground />);

--- a/src/storybook-app/FormField/StyledBackground.js
+++ b/src/storybook-app/FormField/StyledBackground.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import styled from 'styled-components';
+import {FormField, Label} from '../../lib/form-field';
+import { Input } from '../../lib/input';
+import { GREY } from '../../cdk/theme/colors';
+
+/**
+ * Target the `data-hook=form-field-bar` to get the appropriate div and then you can apply
+ * background styling.
+ *
+ * This is no different from declaring `.form-field .form-field-bar` CSS style.
+ */
+const BackgroundFormField = styled(FormField)`
+  && [data-hook=form-field-bar] {
+    background-color: white;
+  }
+`;
+
+class StyledBackground extends React.Component {
+  constructor() {
+    super();
+
+    this.state = { value: '' };
+  }
+
+  updateText = (event) => {
+    this.setState({ value: event.target.value });
+  };
+
+  render() {
+    return (
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '400px',
+        padding: '40px 20px 0',
+        margin: '100px auto',
+        backgroundColor: GREY[100],
+      }}>
+        <BackgroundFormField>
+          <Label>Superhero</Label>
+          <Input
+            as="select"
+            value={this.state.value}
+            onChange={this.updateText}
+            placeholder="Favorite Marvel superhero"
+          >
+            <option value="">Select</option>
+            <option value="iron-man">Iron Man</option>
+            <option value="hulk">Incredible Hulk</option>
+            <option value="thor">Thor</option>
+            <option value="black-widow">Black Widow</option>
+            <option value="cap">Captain America</option>
+          </Input>
+        </BackgroundFormField>
+      </div>
+    );
+  }
+}
+
+export default StyledBackground;

--- a/src/storybook-app/FormField/StyledBackground.js
+++ b/src/storybook-app/FormField/StyledBackground.js
@@ -16,6 +16,10 @@ const BackgroundFormField = styled(FormField)`
   }
 `;
 
+const BackgroundInput = styled(Input)`
+  && { color: green; }
+`;
+
 class StyledBackground extends React.Component {
   constructor() {
     super();
@@ -39,8 +43,8 @@ class StyledBackground extends React.Component {
       }}>
         <BackgroundFormField>
           <Label>Superhero</Label>
-          <Input
-            as="select"
+          <BackgroundInput
+            is="select"
             value={this.state.value}
             onChange={this.updateText}
             placeholder="Favorite Marvel superhero"
@@ -51,7 +55,7 @@ class StyledBackground extends React.Component {
             <option value="thor">Thor</option>
             <option value="black-widow">Black Widow</option>
             <option value="cap">Captain America</option>
-          </Input>
+          </BackgroundInput>
         </BackgroundFormField>
       </div>
     );


### PR DESCRIPTION
# Overview
This change allows users to target the "form field bar" section of the `<FormField>` component and allow them to change the background color. Ordinarily, the color is transparent, which is ideal for white backgrounds. However, in the admin site, the default color is grey, and as such, a white background would be preferred.

This can be accomplished by targeting the `.form-field-bar` equivalent CSS style. Since styled-component names are obfuscated, and since we would not like to target `&& div > div > div`, the easiest way to target the element is by using a `data-hook` attribute. For the `.form-field-bar`,  this was accomplished internally via `<FormFieldBar data-hook="form-field-bar">`. Thus, styling it is cleaner:
```css
&& [data-hook=form-field-bar] {
  background-color: white; // or whatever color you would want
}
```
Semantically, this is similar to using a CSS selector like
```css
.form-field .form-field-bar {
  background-color: white;  // Same as above, if we used CSS classes instead of styled-components
}
```
# Testing
Run `npm run storybook` and check out the "Form Field > with styled background" storybook section