### PR TITLE
Core: export typographic-utils methods

### DIFF
--- a/src/lib/core/exports.js
+++ b/src/lib/core/exports.js
@@ -1,5 +1,6 @@
 export { default as SUIProvider } from './SUIProvider';
 export { generateTypographyConfig, generateTypographyLevel, DEFAULT_TYPOGRAPHY_CONFIG } from './theming/typography';
+export { getLineHeight, getFontWeight, getFontSize, getFontFamily, getPropertyValue, convertLevelToStyles, convertPropertiesToShorthand } from './theming/typographic-utils';
 export { generatePalette, generateThemeColors, getColor, DEFAULT_THEME_CONFIG } from './theming/colors';
 export * from '../../cdk/theme/colors';
 export * from './option';


### PR DESCRIPTION
I added `export` in `typography-utils`  fixing #7 